### PR TITLE
zapix/7 user login backend

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,7 +21,7 @@ Mako==1.1.4
 MarkupSafe==2.0.1
 matplotlib-inline==0.1.2
 mccabe==0.6.1
-mtpylon==0.0.1
+mtpylon==0.0.2
 multidict==5.1.0
 mypy==0.910
 mypy-extensions==0.4.3

--- a/backend/rsa_keys.py
+++ b/backend/rsa_keys.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from typing import List
 import rsa  # type: ignore
-from mtpylon.crypto import KeyPair  # type: ignore
+from mtpylon.crypto import KeyPair
 
 
 def get_rsa_keys(count: int = 2) -> List[KeyPair]:

--- a/backend/schema/__init__.py
+++ b/backend/schema/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from mtpylon import Schema  # type: ignore
+from mtpylon import Schema
 
 
 from .constructors import User

--- a/backend/schema/__init__.py
+++ b/backend/schema/__init__.py
@@ -3,11 +3,14 @@ from mtpylon import Schema  # type: ignore
 
 
 from .constructors import User
-from .functions import register
+from .functions import register, login
 
 mtpylon_schema = Schema(
     constructors=[User],
-    functions=[register]
+    functions=[
+        register,
+        login,
+    ]
 )
 
 __all__ = [

--- a/backend/schema/functions/__init__.py
+++ b/backend/schema/functions/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from .register_func import register
+from .login_func import login
 
 __all__ = [
     'register',
+    'login',
 ]

--- a/backend/schema/functions/login_func.py
+++ b/backend/schema/functions/login_func.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from aiohttp.web import Request
+from mtpylon.crypto import AuthKey  # type: ignore
 from mtpylon.exceptions import RpcCallError  # type: ignore
+from mtpylon.contextvars import auth_key_var  # type: ignore
 
-from users.utils import login_user
+from users.utils import login_user, remember_user
 from ..constructors import User, RegisteredUser
 
 
@@ -11,5 +13,8 @@ async def login(request: Request, nickname: str, password: str) -> User:
         user = await login_user(nickname, password)
     except ValueError as e:
         raise RpcCallError(error_code=401, error_message=str(e))
+
+    auth_key: AuthKey = auth_key_var.get()
+    await remember_user(user, auth_key)
 
     return RegisteredUser(id=user.id, nickname=nickname)

--- a/backend/schema/functions/login_func.py
+++ b/backend/schema/functions/login_func.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from aiohttp.web import Request
+from mtpylon.exceptions import RpcCallError  # type: ignore
+
+from users.utils import login_user
+from ..constructors import User, RegisteredUser
+
+
+async def login(request: Request, nickname: str, password: str) -> User:
+    try:
+        user = await login_user(nickname, password)
+    except ValueError as e:
+        raise RpcCallError(error_code=401, error_message=str(e))
+
+    return RegisteredUser(id=user.id, nickname=nickname)

--- a/backend/schema/functions/login_func.py
+++ b/backend/schema/functions/login_func.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from aiohttp.web import Request
-from mtpylon.crypto import AuthKey  # type: ignore
-from mtpylon.exceptions import RpcCallError  # type: ignore
-from mtpylon.contextvars import auth_key_var  # type: ignore
+from mtpylon.crypto import AuthKey
+from mtpylon.exceptions import RpcCallError
+from mtpylon.contextvars import auth_key_var
 
 from users.utils import login_user, remember_user
 from ..constructors import User, RegisteredUser

--- a/backend/schema/functions/register_func.py
+++ b/backend/schema/functions/register_func.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from aiohttp.web import Request
 from mtpylon.exceptions import RpcCallError  # type: ignore
+from mtpylon.contextvars import auth_key_var
 
-from users.utils import register_user
+from users.utils import register_user, remember_user
 from ..constructors import User, RegisteredUser
 
 
@@ -19,6 +20,10 @@ async def register(request: Request, nickname: str, password: str) -> User:
             error_code=400,
             error_message=str(e)
         )
+
+    auth_key = auth_key_var.get()
+
+    await remember_user(user, auth_key)
 
     return RegisteredUser(
         id=user.id,

--- a/backend/schema/functions/register_func.py
+++ b/backend/schema/functions/register_func.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from aiohttp.web import Request
-from mtpylon.exceptions import RpcCallError  # type: ignore
+from mtpylon.exceptions import RpcCallError
 from mtpylon.contextvars import auth_key_var
 
 from users.utils import register_user, remember_user

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,6 +2,7 @@
 import pytest
 from faker import Faker
 
+from mtpylon.crypto import AuthKey  # type: ignore
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 
@@ -39,3 +40,9 @@ async def user(faker: Faker, async_session: sessionmaker) -> User:
         session.add(user)
         await session.commit()
     return user
+
+
+@pytest.fixture
+def mtpylon_auth_key() -> AuthKey:
+    auth_key_value = 0x4fa4120d3646e1cadc7e21fcc9c46111ff8467665908a56b18bd38bee60ee1cccc2eff69dda5e638be2b06e813e6d9832142a054d22f405d9d416f79168140d373b048f55924b836ec5be2ab92e29624edf67bd5d763f8a15c3aed587e7ac70f8fe0d78de45c4b9ea5b81a1e0a098eb064dc9609fa37ca33f703b48461aed343aabc1498dd4d1cbbf3ca4c56cc8c7dc315e251e28312ed258c74326729118251f9153f7ac9d52bd47fdf7072963f6330f06bb72e2cc744af91df3302800e80c23c25a402b97bfc5292589b1c688bd1fde0e9997d9996a32ebd39ba258137b123fa762fd07548c44fd1b9321778f6ec3464ae39402c0445bd02fa8223b30cdfc8  # noqa
+    return AuthKey(value=auth_key_value)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,7 +2,7 @@
 import pytest
 from faker import Faker
 
-from mtpylon.crypto import AuthKey  # type: ignore
+from mtpylon.crypto import AuthKey
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 

--- a/backend/tests/schema/functions/test_login.py
+++ b/backend/tests/schema/functions/test_login.py
@@ -3,8 +3,8 @@ import pytest
 from contextlib import ExitStack
 from unittest.mock import patch, AsyncMock, MagicMock
 
-from mtpylon.contextvars import auth_key_var  # type: ignore
-from mtpylon.exceptions import RpcCallError  # type: ignore
+from mtpylon.contextvars import auth_key_var
+from mtpylon.exceptions import RpcCallError
 
 from schema.functions.login_func import login
 from schema.constructors import RegisteredUser

--- a/backend/tests/schema/functions/test_login.py
+++ b/backend/tests/schema/functions/test_login.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import pytest
+from contextlib import ExitStack
 from unittest.mock import patch, AsyncMock, MagicMock
 
+from mtpylon.contextvars import auth_key_var  # type: ignore
 from mtpylon.exceptions import RpcCallError  # type: ignore
 
 from schema.functions.login_func import login
@@ -21,15 +23,28 @@ async def test_login_failed():
 
 
 @pytest.mark.asyncio
-async def test_login_success():
+async def test_login_success(mtpylon_auth_key):
+    auth_key_var.set(mtpylon_auth_key)
+
     request = MagicMock()
 
     login_user = AsyncMock()
     login_user.return_value = MagicMock(id=12, nickname='zapix')
 
-    with patch('schema.functions.login_func.login_user', login_user):
+    remember_user = AsyncMock()
+
+    with ExitStack() as patcher:
+        patcher.enter_context(
+            patch('schema.functions.login_func.login_user', login_user)
+        )
+        patcher.enter_context(
+            patch('schema.functions.login_func.remember_user', remember_user)
+        )
+
         user_data = await login(request, 'zapix', 'password123')
 
     assert isinstance(user_data, RegisteredUser)
     assert user_data.id == 12
     assert user_data.nickname == 'zapix'
+
+    remember_user.assert_awaited()

--- a/backend/tests/schema/functions/test_login.py
+++ b/backend/tests/schema/functions/test_login.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+
+from mtpylon.exceptions import RpcCallError  # type: ignore
+
+from schema.functions.login_func import login
+from schema.constructors import RegisteredUser
+
+
+@pytest.mark.asyncio
+async def test_login_failed():
+    request = MagicMock()
+
+    login_user = AsyncMock()
+    login_user.side_effect = ValueError('Authentication Failed')
+
+    with patch('schema.functions.login_func.login_user', login_user):
+        with pytest.raises(RpcCallError):
+            await login(request, 'zapix', 'password123')
+
+
+@pytest.mark.asyncio
+async def test_login_success():
+    request = MagicMock()
+
+    login_user = AsyncMock()
+    login_user.return_value = MagicMock(id=12, nickname='zapix')
+
+    with patch('schema.functions.login_func.login_user', login_user):
+        user_data = await login(request, 'zapix', 'password123')
+
+    assert isinstance(user_data, RegisteredUser)
+    assert user_data.id == 12
+    assert user_data.nickname == 'zapix'

--- a/backend/tests/schema/functions/test_register.py
+++ b/backend/tests/schema/functions/test_register.py
@@ -4,7 +4,7 @@ from contextlib import ExitStack
 from unittest.mock import patch, MagicMock, AsyncMock
 
 from mtpylon.contextvars import auth_key_var
-from mtpylon.exceptions import RpcCallError  # type: ignore
+from mtpylon.exceptions import RpcCallError
 
 from schema.functions.register_func import register
 from schema.constructors import RegisteredUser

--- a/backend/tests/schema/functions/test_register.py
+++ b/backend/tests/schema/functions/test_register.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import pytest
+from contextlib import ExitStack
 from unittest.mock import patch, MagicMock, AsyncMock
 
+from mtpylon.contextvars import auth_key_var
 from mtpylon.exceptions import RpcCallError  # type: ignore
 
 from schema.functions.register_func import register
@@ -9,7 +11,9 @@ from schema.constructors import RegisteredUser
 
 
 @pytest.mark.asyncio
-async def test_register_success():
+async def test_register_success(mtpylon_auth_key):
+    auth_key_var.set(mtpylon_auth_key)
+
     request = MagicMock()
 
     mocked_user = MagicMock(
@@ -19,11 +23,28 @@ async def test_register_success():
     register_user = AsyncMock()
     register_user.return_value = mocked_user
 
-    with patch('schema.functions.register_func.register_user', register_user):
+    remember_user = AsyncMock()
+
+    with ExitStack() as patcher:
+        patcher.enter_context(
+            patch(
+                'schema.functions.register_func.register_user',
+                register_user
+            )
+        )
+        patcher.enter_context(
+            patch(
+                'schema.functions.register_func.remember_user',
+                remember_user
+            )
+        )
+
         result = await register(request, 'johndoe', '12345')
 
     register_user.assert_awaited()
     assert isinstance(result, RegisteredUser)
+
+    remember_user.assert_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/users/test_dal.py
+++ b/backend/tests/users/test_dal.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from mtpylon.crypto import AuthKey  # type: ignore
+
 from users.dal import (
     create_user,
     get_user,
+    create_auth_key,
 )
 
 
@@ -58,3 +61,15 @@ async def test_get_user_by_id_none(async_session):
         returned_user = await get_user(session, user_id=-1)
 
     assert returned_user is None
+
+
+@pytest.mark.asyncio
+async def test_create_auth_key(async_session, user):
+    auth_key_value = 0x4fa4120d3646e1cadc7e21fcc9c46111ff8467665908a56b18bd38bee60ee1cccc2eff69dda5e638be2b06e813e6d9832142a054d22f405d9d416f79168140d373b048f55924b836ec5be2ab92e29624edf67bd5d763f8a15c3aed587e7ac70f8fe0d78de45c4b9ea5b81a1e0a098eb064dc9609fa37ca33f703b48461aed343aabc1498dd4d1cbbf3ca4c56cc8c7dc315e251e28312ed258c74326729118251f9153f7ac9d52bd47fdf7072963f6330f06bb72e2cc744af91df3302800e80c23c25a402b97bfc5292589b1c688bd1fde0e9997d9996a32ebd39ba258137b123fa762fd07548c44fd1b9321778f6ec3464ae39402c0445bd02fa8223b30cdfc8  # noqa
+    mtpylon_auth_key = AuthKey(value=auth_key_value)
+
+    async with async_session() as session:
+        auth_key = await create_auth_key(session, user, mtpylon_auth_key)
+
+    assert auth_key.id is not None
+    assert auth_key.auth_key_id == mtpylon_auth_key.id

--- a/backend/tests/users/test_dal.py
+++ b/backend/tests/users/test_dal.py
@@ -10,6 +10,10 @@ from users.dal import (
 )
 
 
+auth_key_value = 0x4fa4120d3646e1cadc7e21fcc9c46111ff8467665908a56b18bd38bee60ee1cccc2eff69dda5e638be2b06e813e6d9832142a054d22f405d9d416f79168140d373b048f55924b836ec5be2ab92e29624edf67bd5d763f8a15c3aed587e7ac70f8fe0d78de45c4b9ea5b81a1e0a098eb064dc9609fa37ca33f703b48461aed343aabc1498dd4d1cbbf3ca4c56cc8c7dc315e251e28312ed258c74326729118251f9153f7ac9d52bd47fdf7072963f6330f06bb72e2cc744af91df3302800e80c23c25a402b97bfc5292589b1c688bd1fde0e9997d9996a32ebd39ba258137b123fa762fd07548c44fd1b9321778f6ec3464ae39402c0445bd02fa8223b30cdfc8  # noqa
+mtpylon_auth_key = AuthKey(value=auth_key_value)
+
+
 @pytest.mark.asyncio
 async def test_create_user(async_session):
     async with async_session() as session:
@@ -64,10 +68,25 @@ async def test_get_user_by_id_none(async_session):
 
 
 @pytest.mark.asyncio
-async def test_create_auth_key(async_session, user):
-    auth_key_value = 0x4fa4120d3646e1cadc7e21fcc9c46111ff8467665908a56b18bd38bee60ee1cccc2eff69dda5e638be2b06e813e6d9832142a054d22f405d9d416f79168140d373b048f55924b836ec5be2ab92e29624edf67bd5d763f8a15c3aed587e7ac70f8fe0d78de45c4b9ea5b81a1e0a098eb064dc9609fa37ca33f703b48461aed343aabc1498dd4d1cbbf3ca4c56cc8c7dc315e251e28312ed258c74326729118251f9153f7ac9d52bd47fdf7072963f6330f06bb72e2cc744af91df3302800e80c23c25a402b97bfc5292589b1c688bd1fde0e9997d9996a32ebd39ba258137b123fa762fd07548c44fd1b9321778f6ec3464ae39402c0445bd02fa8223b30cdfc8  # noqa
-    mtpylon_auth_key = AuthKey(value=auth_key_value)
+async def test_get_user_by_auth_key(async_session, user):
+    async with async_session() as session:
+        await create_auth_key(session, user, mtpylon_auth_key)
+        returned_user = await get_user(session, auth_key=mtpylon_auth_key)
 
+    assert returned_user is not None
+    assert returned_user.id == user.id
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_auth_key_none(async_session, user):
+    async with async_session() as session:
+        returned_user = await get_user(session, auth_key=mtpylon_auth_key)
+
+    assert returned_user is None
+
+
+@pytest.mark.asyncio
+async def test_create_auth_key(async_session, user):
     async with async_session() as session:
         auth_key = await create_auth_key(session, user, mtpylon_auth_key)
 

--- a/backend/tests/users/test_dal.py
+++ b/backend/tests/users/test_dal.py
@@ -1,17 +1,11 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from mtpylon.crypto import AuthKey  # type: ignore
-
 from users.dal import (
     create_user,
     get_user,
     create_auth_key,
 )
-
-
-auth_key_value = 0x4fa4120d3646e1cadc7e21fcc9c46111ff8467665908a56b18bd38bee60ee1cccc2eff69dda5e638be2b06e813e6d9832142a054d22f405d9d416f79168140d373b048f55924b836ec5be2ab92e29624edf67bd5d763f8a15c3aed587e7ac70f8fe0d78de45c4b9ea5b81a1e0a098eb064dc9609fa37ca33f703b48461aed343aabc1498dd4d1cbbf3ca4c56cc8c7dc315e251e28312ed258c74326729118251f9153f7ac9d52bd47fdf7072963f6330f06bb72e2cc744af91df3302800e80c23c25a402b97bfc5292589b1c688bd1fde0e9997d9996a32ebd39ba258137b123fa762fd07548c44fd1b9321778f6ec3464ae39402c0445bd02fa8223b30cdfc8  # noqa
-mtpylon_auth_key = AuthKey(value=auth_key_value)
 
 
 @pytest.mark.asyncio
@@ -68,7 +62,7 @@ async def test_get_user_by_id_none(async_session):
 
 
 @pytest.mark.asyncio
-async def test_get_user_by_auth_key(async_session, user):
+async def test_get_user_by_auth_key(async_session, user, mtpylon_auth_key):
     async with async_session() as session:
         await create_auth_key(session, user, mtpylon_auth_key)
         returned_user = await get_user(session, auth_key=mtpylon_auth_key)
@@ -78,7 +72,7 @@ async def test_get_user_by_auth_key(async_session, user):
 
 
 @pytest.mark.asyncio
-async def test_get_user_by_auth_key_none(async_session, user):
+async def test_get_user_by_auth_key_none(async_session, mtpylon_auth_key):
     async with async_session() as session:
         returned_user = await get_user(session, auth_key=mtpylon_auth_key)
 
@@ -86,7 +80,7 @@ async def test_get_user_by_auth_key_none(async_session, user):
 
 
 @pytest.mark.asyncio
-async def test_create_auth_key(async_session, user):
+async def test_create_auth_key(async_session, user, mtpylon_auth_key):
     async with async_session() as session:
         auth_key = await create_auth_key(session, user, mtpylon_auth_key)
 

--- a/backend/tests/users/test_utils.py
+++ b/backend/tests/users/test_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 from unittest.mock import patch
-from users.utils import encode_password, register_user
+from users.utils import encode_password, register_user, login_user
 
 
 def test_encode_password():
@@ -35,3 +35,25 @@ async def test_register_user_success(async_session):
 
     assert user is not None
     assert user.nickname == 'zap.aibulatov'
+
+
+@pytest.mark.asyncio
+async def test_login_user_no_user(async_session):
+    with patch('users.utils.async_session', async_session):
+        with pytest.raises(ValueError):
+            await login_user('unknown_user', 'random_password')
+
+
+@pytest.mark.asyncio
+async def test_login_user_wrong_password(async_session, user):
+    with patch('users.utils.async_session', async_session):
+        with pytest.raises(ValueError):
+            await login_user(user.nickname, 'random_password')
+
+
+@pytest.mark.asyncio
+async def test_login_user_success(async_session, user):
+    with patch('users.utils.async_session', async_session):
+        logged_in_user = await login_user(user.nickname, 'hello_world')
+
+    assert logged_in_user.id == user.id

--- a/backend/users/dal.py
+++ b/backend/users/dal.py
@@ -5,7 +5,9 @@ from sqlalchemy import select
 from sqlalchemy.sql import Select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from .models import User
+from mtpylon.crypto import AuthKey as MtpylonAuthKey  # type: ignore
+
+from .models import User, AuthKey
 
 
 async def create_user(
@@ -46,3 +48,21 @@ async def get_user(
         user = cast(User, row[0])
 
     return user
+
+
+async def create_auth_key(
+        session: AsyncSession,
+        user: User,
+        auth_key: MtpylonAuthKey
+) -> AuthKey:
+    """
+    Creates auth key for user
+    """
+    key = AuthKey(
+        auth_key_id=auth_key.id,
+        user_id=user.id
+    )
+    session.add(key)
+    await session.commit()
+
+    return key

--- a/backend/users/dal.py
+++ b/backend/users/dal.py
@@ -5,7 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.sql import Select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from mtpylon.crypto import AuthKey as MtpylonAuthKey  # type: ignore
+from mtpylon.crypto import AuthKey as MtpylonAuthKey
 
 from .models import User, AuthKey
 

--- a/backend/users/dal.py
+++ b/backend/users/dal.py
@@ -31,6 +31,7 @@ async def get_user(
     session: AsyncSession,
     user_id: Optional[int] = None,
     nickname: Optional[str] = None,
+    auth_key: Optional[MtpylonAuthKey] = None,
 ) -> Optional[User]:
     stmt: Select = select(User)
 
@@ -39,6 +40,9 @@ async def get_user(
 
     if nickname is not None:
         stmt = stmt.where(User.nickname == nickname)
+
+    if auth_key is not None:
+        stmt = stmt.join(AuthKey).where(AuthKey.auth_key_id == auth_key.id)
 
     result = await session.execute(stmt)
     row = result.one_or_none()

--- a/backend/users/utils.py
+++ b/backend/users/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from hashlib import sha1
 
-from mtpylon.crypto import AuthKey as MtpylonAuthKey  # type: ignore
+from mtpylon.crypto import AuthKey as MtpylonAuthKey
 
 from db import async_session
 from .models import User

--- a/backend/users/utils.py
+++ b/backend/users/utils.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 from hashlib import sha1
 
+from mtpylon.crypto import AuthKey as MtpylonAuthKey  # type: ignore
+
 from db import async_session
 from .models import User
-from .dal import get_user, create_user
+from .dal import get_user, create_user, create_auth_key
 
 AUTH_ERROR_MESSAGE = 'Authentication has been failed'
 
@@ -66,3 +68,11 @@ async def login_user(nickname: str, password: str) -> User:
         raise ValueError(AUTH_ERROR_MESSAGE)
 
     return user
+
+
+async def remember_user(user: User, auth_key: MtpylonAuthKey):
+    """
+    Creates auth key for user
+    """
+    async with async_session() as session:
+        await create_auth_key(session, user, auth_key)

--- a/backend/users/utils.py
+++ b/backend/users/utils.py
@@ -5,6 +5,8 @@ from db import async_session
 from .models import User
 from .dal import get_user, create_user
 
+AUTH_ERROR_MESSAGE = 'Authentication has been failed'
+
 
 def encode_password(password: str) -> str:
     """
@@ -44,3 +46,23 @@ async def register_user(nickname: str, password: str) -> User:
         )
 
     return new_user
+
+
+async def login_user(nickname: str, password: str) -> User:
+    """
+    Checks user with current credentials
+    Raises:
+        ValueError - if something goes wrong
+    """
+    async with async_session() as session:
+        user = await get_user(session, nickname=nickname)
+
+    if user is None:
+        raise ValueError(AUTH_ERROR_MESSAGE)
+
+    hashed_password = encode_password(password)
+
+    if hashed_password != user.password:
+        raise ValueError(AUTH_ERROR_MESSAGE)
+
+    return user

--- a/backend/web.py
+++ b/backend/web.py
@@ -6,7 +6,7 @@ from aiohttp import web
 import aiohttp_cors  # type: ignore
 from dotenv import load_dotenv
 
-from mtpylon.configuration import configure_app  # type: ignore
+from mtpylon.configuration import configure_app
 
 from schema import mtpylon_schema
 from rsa_keys import get_rsa_keys


### PR DESCRIPTION
- Create auth key
- Get user by auth_key
- Check login credentials for
- Set mtpylon as auth_key fixture
- Add login mtpylon function
- Add function to remember user by auth_key
- Remember user after login
- Remember user after registration
- Update mtpylon version
- Remove ignoring typing for mtpylon lib

Closes #7 